### PR TITLE
Add save image to disk feature (Ctrl+S)

### DIFF
--- a/src/applications/qlippy-backend/src/clipboard/handle-save.ts
+++ b/src/applications/qlippy-backend/src/clipboard/handle-save.ts
@@ -1,0 +1,35 @@
+import {
+    saveClipboardHistoryEventName,
+    SaveClipboardHistoryEventData
+} from "qlippy-common/src/events/saveClipboardHistory.event";
+import {clipboardManager} from "./manager";
+import {eventHandler} from "backend-essentials/src/utilities/eventHandler";
+import {saveFileAs} from "backend-essentials/src/files/saveFileAs";
+import {clipboardHistoryWindow} from "../windows/clipboard-history.window";
+
+const createClipboardHandleSave = () => {
+    return {
+        initialize: async (): Promise<void> => {
+            eventHandler.listen<SaveClipboardHistoryEventData>(saveClipboardHistoryEventName, async ({id}) => {
+                const item = clipboardManager.getById(id);
+
+                if (!item || item.type !== 'image' || !item.imageFilePath) {
+                    return;
+                }
+
+                try {
+                    await saveFileAs({
+                        sourcePath: item.imageFilePath,
+                        suggestedName: `clipboard-${item.id}.png`,
+                        filters: [{name: 'PNG Image', extensions: ['png']}],
+                        window: clipboardHistoryWindow.getWindow(),
+                    });
+                } catch (error) {
+                    console.error('Failed to save image:', error);
+                }
+            });
+        }
+    }
+}
+
+export const clipboardHandleSave = createClipboardHandleSave();

--- a/src/applications/qlippy-backend/src/main.ts
+++ b/src/applications/qlippy-backend/src/main.ts
@@ -16,6 +16,7 @@ import {clipboardHandleRestore} from "./clipboard/handle-restore";
 import {clipboardChangeEmitter} from "./clipboard/change-emitter";
 import {clipboardSettings} from "./settings/clipboard.setting";
 import {clipboardHandleOpen} from "./clipboard/handle-open";
+import {clipboardHandleSave} from "./clipboard/handle-save";
 import {settingsManager} from "backend-essentials/src/settings/settingsManager";
 import {settingsWindow} from "./windows/settings.window";
 
@@ -53,6 +54,7 @@ if (!isSingleInstance) {
         await clipboardHandleClear.initialize();
         await clipboardHandleRestore.initialize();
         await clipboardHandleOpen.initialize();
+        await clipboardHandleSave.initialize();
 
         // Background Processes
         await keyboardShortcuts.initialize();

--- a/src/applications/qlippy-common/src/events/saveClipboardHistory.event.ts
+++ b/src/applications/qlippy-common/src/events/saveClipboardHistory.event.ts
@@ -1,0 +1,7 @@
+import {ClipboardId} from "../settings/clipboard.settings.types";
+
+export const saveClipboardHistoryEventName = 'saveClipboardHistory';
+
+export type SaveClipboardHistoryEventData = {
+    id: ClipboardId;
+};

--- a/src/applications/qlippy-frontend/app/clipboard-history/clipboard-menu.tsx
+++ b/src/applications/qlippy-frontend/app/clipboard-history/clipboard-menu.tsx
@@ -25,6 +25,7 @@ const fileKeyCombos = {
 
 const imageKeyCombos = {
     'Ctrl+I': 'Open the image externally',
+    'Ctrl+S': 'Save the image to disk',
 }
 
 const urlKeyCombos = {

--- a/src/applications/qlippy-frontend/app/clipboard-history/clipboard-query.tsx
+++ b/src/applications/qlippy-frontend/app/clipboard-history/clipboard-query.tsx
@@ -15,6 +15,7 @@ export type ClipboardQueryParams = {
     pinSelected: () => void,
     restoreSelectedImage: () => void,
     restoreSelectedText: () => void,
+    saveSelected: () => void,
     close: () => void,
     isMenuShown: boolean,
     showMenu: () => void,
@@ -48,6 +49,7 @@ export const ClipboardQuery = memo(({
                                         pinSelected,
                                         restoreSelectedImage,
                                         restoreSelectedText,
+                                        saveSelected,
                                         close,
                                         isMenuShown,
                                         showMenu,
@@ -92,6 +94,12 @@ export const ClipboardQuery = memo(({
                         restoreSelectedText();
                     }
                     break;
+                case 'KeyS':
+                    event.preventDefault();
+                    if (item?.type === 'image') {
+                        saveSelected();
+                    }
+                    break;
             }
         } else {
             switch (event.code) {
@@ -113,7 +121,7 @@ export const ClipboardQuery = memo(({
                     break;
             }
         }
-    }, [selectNext, selectPrevious, confirmSelected, close, deleteSelected, showMenu, hideMenu, openSelected, updateQuery]);
+    }, [selectNext, selectPrevious, confirmSelected, close, deleteSelected, showMenu, hideMenu, openSelected, updateQuery, saveSelected]);
     const [currentTip] = useState(getRandomTip());
 
     const handleKeyUp: KeyboardEventHandler<HTMLInputElement> = useCallback((event) => {

--- a/src/applications/qlippy-frontend/app/clipboard-history/page.tsx
+++ b/src/applications/qlippy-frontend/app/clipboard-history/page.tsx
@@ -33,6 +33,10 @@ import {
     RestoreTextClipboardHistoryEventData,
     restoreTextClipboardHistoryEventName
 } from 'qlippy-common/src/events/restoreTextClipboardHistory.event'
+import {
+    SaveClipboardHistoryEventData,
+    saveClipboardHistoryEventName
+} from 'qlippy-common/src/events/saveClipboardHistory.event'
 import {useWindowControls} from "frontend-essentials/src/hooks/useWindowControls";
 import {toHumanDateAgo} from 'common-essentials/src/utilities/date'
 import {ClipboardMenu} from "./clipboard-menu";
@@ -218,6 +222,14 @@ export default function ClipboardHistoryPage() {
         setSelectedIndex(0);
     }, [selectedItem, setSelectedIndex]);
 
+    const saveSelected = useCallback(() => {
+        if (selectedItem && selectedItem.type === 'image' && 'imageFilePath' in selectedItem && !!selectedItem.imageFilePath) {
+            eventHandler.emit<SaveClipboardHistoryEventData>(saveClipboardHistoryEventName, {
+                id: selectedItem.id
+            });
+        }
+    }, [selectedItem]);
+
     const clearSelected = useCallback(() => {
         if (selectedItem) {
             eventHandler.emit<ClearClipboardHistoryEventData>(clearClipboardHistoryEventName, {
@@ -302,6 +314,7 @@ export default function ClipboardHistoryPage() {
                         pinSelected={pinSelected}
                         restoreSelectedImage={restoreSelectedImage}
                         restoreSelectedText={restoreSelectedText}
+                        saveSelected={saveSelected}
                         close={handleClose}
                         isMenuShown={showMenu}
                         showMenu={handleShowMenu}

--- a/src/packages/backend-essentials/src/files/saveFileAs.ts
+++ b/src/packages/backend-essentials/src/files/saveFileAs.ts
@@ -1,0 +1,36 @@
+import {dialog, BrowserWindow} from 'electron';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+type SaveFileAsParams = {
+    sourcePath: string;
+    suggestedName?: string;
+    filters?: Array<{ name: string; extensions: string[] }>;
+    window?: BrowserWindow;
+};
+
+type SaveFileAsResult = {
+    canceled: true;
+} | {
+    canceled: false;
+    destinationPath: string;
+};
+
+export const saveFileAs = async (params: SaveFileAsParams): Promise<SaveFileAsResult> => {
+    const {sourcePath, suggestedName, filters, window} = params;
+
+    const defaultName = suggestedName ?? path.basename(sourcePath);
+
+    const result = await dialog.showSaveDialog(window, {
+        defaultPath: defaultName,
+        filters: filters ?? [{name: 'All Files', extensions: ['*']}],
+    });
+
+    if (result.canceled || !result.filePath) {
+        return {canceled: true};
+    }
+
+    await fs.copyFile(sourcePath, result.filePath);
+
+    return {canceled: false, destinationPath: result.filePath};
+};


### PR DESCRIPTION
- Add reusable saveFileAs utility in backend-essentials for Electron save dialog
- Add saveClipboardHistory event in qlippy-common
- Add handle-save.ts in qlippy-backend to process save events
- Register save handler in main.ts
- Add Ctrl+S keyboard shortcut for images in qlippy-frontend
- Update help menu to show Ctrl+S for images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export images from clipboard history directly to disk using the Ctrl+S keyboard shortcut
  * File save dialog for selecting destination folder and customizing saved filenames

<!-- end of auto-generated comment: release notes by coderabbit.ai -->